### PR TITLE
Feature/gh 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
   "jest": {
     "verbose": true,
     "preset": "ts-jest",
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "globals": {
+      "ts-jest": {
+        "diagnostics": false
+      }
+    }
   }
 }

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -1,6 +1,6 @@
 import { Scene } from 'phaser';
-import { Game } from './scenes';
+import { Game, End } from './scenes';
 
 export default class SceneManager {
-  public static scenes: typeof Scene[] = [Game];
+  public static scenes: typeof Scene[] = [Game, End];
 }

--- a/src/scenes/end/EndScene.ts
+++ b/src/scenes/end/EndScene.ts
@@ -1,0 +1,38 @@
+import { Scene } from 'phaser';
+
+export default class End extends Scene {
+  private score: number = 0;
+  constructor() {
+    super('End');
+  }
+
+  init(data: any) {
+    this.score = data.score;
+  }
+
+  create() {
+    this.add
+      .text(400, 50, 'Super Radical Tapper!', { font: '40px Clarity' })
+      .setOrigin(0.5);
+
+    this.add
+      .text(400, 150, 'You Lost 💀', { font: '32px Clarity' })
+      .setOrigin(0.5);
+
+    this.add
+      .text(400, 200, `Final Score: ${this.score.toString()}`, {
+        font: '32px Clarity',
+      })
+      .setOrigin(0.5);
+
+    const restart = this.add
+      .text(400, 400, 'Restart', {
+        font: '32px Clarity',
+      })
+      .setOrigin(0.5);
+
+    restart.setInteractive().on('pointerup', () => {
+      this.scene.start('Game', { restart: true });
+    });
+  }
+}

--- a/src/scenes/game/CueContainer.spec.ts
+++ b/src/scenes/game/CueContainer.spec.ts
@@ -1,19 +1,18 @@
 import { Input, Scene } from 'phaser';
 import CueContainer from './CueContainer';
+import eventsCenter from './EventsCenter';
+
+jest.mock('./EventsCenter', () => ({
+  emit: jest.fn(),
+  on: jest.fn(),
+}));
 
 jest.mock('phaser', () => ({
   __esModule: true,
   GameObjects: {
     Container: jest.fn(),
   },
-  Scene: jest.fn().mockImplementation(() => ({
-    events: {
-      emit: jest.fn(),
-      on: jest.fn().mockImplementation((_event: string, callback: Function) => {
-        callback('R');
-      }),
-    },
-  })),
+  Scene: jest.fn(),
   Input: {
     Keyboard: {
       KeyCodes: {
@@ -38,17 +37,11 @@ const mockScene = new Scene({});
 
 describe('CueContainer', () => {
   describe('event listening', () => {
-    it('emits a reset event in response to a presentCue event', () => {
-      new CueContainer(mockScene);
-      mockScene.events.emit('presentCue');
-
-      expect(mockScene.events.emit).toHaveBeenCalledWith('reset');
-    });
-
-    it('sets the highlighted cue to the provided cue key and highlights it', () => {
+    it('resets the field, then highlights the cue for the provided key', () => {
       const container = new CueContainer(mockScene);
-      mockScene.events.emit('presentCue');
+      container.presentCue('R');
 
+      expect(eventsCenter.emit).toHaveBeenCalledWith('reset');
       expect(container.highlightedCue.id).toEqual('R');
       expect(container.highlightedCue.highlight).toHaveBeenCalled();
     });

--- a/src/scenes/game/CueContainer.ts
+++ b/src/scenes/game/CueContainer.ts
@@ -1,4 +1,5 @@
 import { GameObjects, Scene } from 'phaser';
+import eventsCenter from './EventsCenter';
 import { Cue } from '../../objects';
 import CueFacet from './CueFacet';
 
@@ -18,7 +19,7 @@ export default class CueContainer extends GameObjects.Container {
       radius: 50,
       text: 'D',
       key: CueFacet.CUE_FACETS[0].key,
-      eventEmitter: this.scene.events,
+      eventEmitter: eventsCenter,
     });
 
     this.cues[CueFacet.CUE_FACETS[1].id] = new Cue(this.scene, {
@@ -28,7 +29,7 @@ export default class CueContainer extends GameObjects.Container {
       radius: 50,
       text: 'F',
       key: CueFacet.CUE_FACETS[1].key,
-      eventEmitter: this.scene.events,
+      eventEmitter: eventsCenter,
     });
 
     this.cues[CueFacet.CUE_FACETS[2].id] = new Cue(this.scene, {
@@ -38,7 +39,7 @@ export default class CueContainer extends GameObjects.Container {
       radius: 50,
       text: 'J',
       key: CueFacet.CUE_FACETS[2].key,
-      eventEmitter: this.scene.events,
+      eventEmitter: eventsCenter,
     });
 
     this.cues[CueFacet.CUE_FACETS[3].id] = new Cue(this.scene, {
@@ -48,12 +49,12 @@ export default class CueContainer extends GameObjects.Container {
       radius: 50,
       text: 'K',
       key: CueFacet.CUE_FACETS[3].key,
-      eventEmitter: this.scene.events,
+      eventEmitter: eventsCenter,
     });
 
-    this.scene.events.on('presentCue', (cueKey: string) => {
+    eventsCenter.on('presentCue', (cueKey: string) => {
       // Reset the cues
-      this.scene.events.emit('reset');
+      eventsCenter.emit('reset');
       // Change the highlighted cue
       this.highlightedCue = this.cues[cueKey];
       this.highlightedCue.highlight();

--- a/src/scenes/game/CueContainer.ts
+++ b/src/scenes/game/CueContainer.ts
@@ -53,12 +53,16 @@ export default class CueContainer extends GameObjects.Container {
     });
 
     eventsCenter.on('presentCue', (cueKey: string) => {
-      // Reset the cues
-      eventsCenter.emit('reset');
-      // Change the highlighted cue
-      this.highlightedCue = this.cues[cueKey];
-      this.highlightedCue.highlight();
+      this.presentCue(cueKey);
     });
+  }
+
+  presentCue(cueKey: string) {
+    // first - reset any cues
+    eventsCenter.emit('reset');
+    // Change the highlighted cue
+    this.highlightedCue = this.cues[cueKey];
+    this.highlightedCue.highlight();
   }
 
   get highlightedCueId(): string {

--- a/src/scenes/game/CueGenerator.spec.ts
+++ b/src/scenes/game/CueGenerator.spec.ts
@@ -1,15 +1,13 @@
-import { Scene } from 'phaser';
 import CueFacet from './CueFacet';
 import CueGenerator from './CueGenerator';
 
+jest.mock('./EventsCenter', () => ({
+  emit: jest.fn(),
+  on: jest.fn(),
+}));
+
 jest.mock('phaser', () => ({
   __esModule: true,
-  Scene: jest.fn().mockImplementation(() => ({
-    events: {
-      emit: jest.fn(),
-      on: jest.fn(),
-    },
-  })),
   Input: {
     Keyboard: {
       KeyCodes: {
@@ -21,8 +19,6 @@ jest.mock('phaser', () => ({
     },
   },
 }));
-
-const mockScene = new Scene({});
 
 describe('CueGenerator', () => {
   describe('nextCue', () => {
@@ -36,7 +32,7 @@ describe('CueGenerator', () => {
         CueFacet.CUE_FACETS[3],
         CueFacet.CUE_FACETS[2],
       ];
-      const generator = new CueGenerator(mockSequence, mockScene);
+      const generator = new CueGenerator(mockSequence);
       jest.spyOn(generator, 'randomCueId').mockReturnValue('FOO');
 
       [...Array(generator.sequenceIterations)].forEach(() => {

--- a/src/scenes/game/CueGenerator.ts
+++ b/src/scenes/game/CueGenerator.ts
@@ -1,4 +1,3 @@
-import { Scene } from 'phaser';
 import eventsCenter from './EventsCenter';
 import CueFacet from './CueFacet';
 
@@ -12,7 +11,7 @@ export default class CueGenerator {
   private _unstructuredPhaseIterator = 0;
   private _inStructuredPhase = true; // TODO: Will need to set this dynamically if we want to change up whether we start with structured or unstructured phase
 
-  constructor(structuredSequence: CueFacet[], scene: Scene) {
+  constructor(structuredSequence: CueFacet[]) {
     this._structuredSequence = structuredSequence.map((facet) => facet.id);
 
     this._presentationPhaseLength =

--- a/src/scenes/game/CueGenerator.ts
+++ b/src/scenes/game/CueGenerator.ts
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import eventsCenter from './EventsCenter';
 import CueFacet from './CueFacet';
 
 export default class CueGenerator {
@@ -20,7 +21,7 @@ export default class CueGenerator {
     this._structuredPresentationPhase = this.buildStructuredPresentationPhase();
     this._cueSelector = this.cueGenerator();
 
-    scene.events.on('restart', () => {
+    eventsCenter.on('restart', () => {
       this._structuredPhaseIterator = this._inStructuredPhase ? -1 : 0; // -1 is here to account for incidental increment in generator
       this._unstructuredPhaseIterator = 0;
       this._inStructuredPhase = true;

--- a/src/scenes/game/EventsCenter.ts
+++ b/src/scenes/game/EventsCenter.ts
@@ -1,0 +1,5 @@
+import { Events } from 'phaser';
+
+const eventsCenter = new Events.EventEmitter();
+
+export default eventsCenter;

--- a/src/scenes/game/GameController.ts
+++ b/src/scenes/game/GameController.ts
@@ -4,6 +4,10 @@ import CueGenerator from './CueGenerator';
 import PhaseController from './PhaseController';
 import { InputEvents } from './InputMediator';
 
+const STARTING_HEALTH = 10;
+const STARTING_STREAK = 0;
+const STARTING_SCORE = 0;
+
 export enum GamePhase {
   START,
   PRESENTATION,
@@ -13,9 +17,9 @@ export enum GamePhase {
 }
 
 export default class GameController {
-  private _score = 0;
-  private _streak = 0;
-  private _health = 10;
+  private _score = STARTING_SCORE;
+  private _streak = STARTING_STREAK;
+  private _health = STARTING_HEALTH;
   private _phaseController: PhaseController;
   private _cueGenerator: CueGenerator;
   private _cueContainer!: CueContainer;
@@ -114,8 +118,8 @@ export default class GameController {
   }
 
   reset(): void {
-    this._score = 0;
-    this._streak = 0;
-    this._health = 3;
+    this._score = STARTING_SCORE;
+    this._streak = STARTING_STREAK;
+    this._health = STARTING_HEALTH;
   }
 }

--- a/src/scenes/game/GameController.ts
+++ b/src/scenes/game/GameController.ts
@@ -1,8 +1,8 @@
-import { Scene } from 'phaser';
+import eventsCenter from './EventsCenter';
 import CueContainer from './CueContainer';
 import CueGenerator from './CueGenerator';
 import PhaseController from './PhaseController';
-import InputMediator, { InputEvents } from './InputMediator';
+import { InputEvents } from './InputMediator';
 
 export enum GamePhase {
   START,
@@ -16,34 +16,21 @@ export default class GameController {
   private _score = 0;
   private _streak = 0;
   private _health = 10;
-  private _scene: Scene;
   private _phaseController: PhaseController;
   private _cueGenerator: CueGenerator;
-  private _cueContainer: CueContainer;
+  private _cueContainer!: CueContainer;
 
-  constructor(
-    scene: Scene,
-    phaseController: PhaseController,
-    cueGenerator: CueGenerator,
-    cueContainer: CueContainer
-  ) {
-    this._scene = scene;
+  constructor(phaseController: PhaseController, cueGenerator: CueGenerator) {
     this._phaseController = phaseController;
     this._cueGenerator = cueGenerator;
-    this._cueContainer = cueContainer;
-
-    InputMediator.mediateKeyboardStream(
-      this._scene.input.keyboard,
-      this._scene.events
-    );
 
     // TODO: The awkward part here is that CueContainer holds rendering info, which we want to de-couple from the game logic. See if that can be moved elsewhere
-    this._scene.events.on('input', (event: InputEvents, data: any) => {
+    eventsCenter.on('input', (event: InputEvents, data: any) => {
       if (
         event == InputEvents.CUE_INPUT &&
         this._phaseController.currentPhase == GamePhase.RESPONSE_COLLECTION
       ) {
-        this._scene.events.emit(
+        eventsCenter.emit(
           'displayResults',
           data.id === this._cueContainer.highlightedCueId
         );
@@ -51,43 +38,43 @@ export default class GameController {
       }
     });
 
-    this._scene.events.on(
+    eventsCenter.on(
       'changePhase',
       (currentPhase: GamePhase, newPhase: GamePhase, premature: boolean) => {
         if (currentPhase === GamePhase.RESPONSE_COLLECTION && !premature) {
-          this._scene.events.emit('displayResults', false);
+          eventsCenter.emit('displayResults', false);
         } else if (newPhase === GamePhase.WAIT) {
-          this._scene.events.emit('reset');
+          eventsCenter.emit('reset');
         } else if (newPhase === GamePhase.PRESENTATION) {
-          this._scene.events.emit('presentCue', this._cueGenerator.nextCue);
+          eventsCenter.emit('presentCue', this._cueGenerator.nextCue);
         }
       }
     );
 
-    this._scene.events.on('displayResults', (correct: boolean) => {
-      correct
-        ? this._scene.events.emit('succeed')
-        : this._scene.events.emit('fail');
+    eventsCenter.on('displayResults', (correct: boolean) => {
+      correct ? eventsCenter.emit('succeed') : eventsCenter.emit('fail');
     });
 
-    this._scene.events.on('succeed', () => {
+    eventsCenter.on('succeed', () => {
       this.incrementStreak();
       this.incrementScore();
     });
 
-    this._scene.events.on('fail', () => {
+    eventsCenter.on('fail', () => {
       this.streak = 0;
       this.decrementHealth();
       if (this.health <= 0) {
-        this._scene.events.emit('restart');
+        eventsCenter.emit('gameOver');
       }
     });
 
-    this._scene.events.on('restart', () => {
-      this.score = 0;
-      this.streak = 0;
-      this.health = 10;
+    eventsCenter.on('restart', () => {
+      this.reset();
     });
+  }
+
+  set cueContainer(cueContainer: CueContainer) {
+    this._cueContainer = cueContainer;
   }
 
   get score(): number {
@@ -124,5 +111,11 @@ export default class GameController {
 
   decrementHealth(): void {
     this._health--;
+  }
+
+  reset(): void {
+    this._score = 0;
+    this._streak = 0;
+    this._health = 3;
   }
 }

--- a/src/scenes/game/GameScene.ts
+++ b/src/scenes/game/GameScene.ts
@@ -1,4 +1,6 @@
 import { Scene, GameObjects } from 'phaser';
+import eventsCenter from './EventsCenter';
+import InputMediator from './InputMediator';
 import GameController from './GameController';
 import CueContainer from './CueContainer';
 import PhaseController from './PhaseController';
@@ -14,14 +16,8 @@ export default class Game extends Scene {
 
   constructor() {
     super('Game');
-  }
-
-  preload() {}
-
-  create() {
     this.gm = new GameController(
-      this,
-      new PhaseController(this),
+      new PhaseController(),
       new CueGenerator(
         [
           CueFacet.CUE_FACETS[0],
@@ -38,9 +34,21 @@ export default class Game extends Scene {
           CueFacet.CUE_FACETS[3],
         ],
         this
-      ),
-      new CueContainer(this)
+      )
     );
+  }
+
+  preload() {}
+
+  init(data: any) {
+    if (data && data.restart) {
+      eventsCenter.emit('restart');
+    }
+    InputMediator.mediateKeyboardStream(this.input.keyboard);
+  }
+
+  create() {
+    this.gm.cueContainer = new CueContainer(this);
 
     this.add
       .text(400, 50, 'Super Radical Tapper!', { font: '40px Clarity' })
@@ -66,20 +74,30 @@ export default class Game extends Scene {
       .text(700, 150, this.gm.health.toString(), { font: '32px Clarity' })
       .setOrigin(0.5);
 
-    this.events.on('succeed', () => {
+    eventsCenter.on('succeed', () => {
       this.scoreText.setText(this.gm.score.toString());
       this.streakText.setText(this.gm.streak.toString());
       this.resultText.setText('SCORE!');
     });
 
-    this.events.on('fail', () => {
+    eventsCenter.on('fail', () => {
       this.streakText.setText(this.gm.streak.toString());
       this.healthText.setText(this.gm.health.toString());
       this.resultText.setText('OUCH!');
     });
 
-    this.events.on('reset', () => {
+    eventsCenter.on('reset', () => {
       this.resultText.setText('');
     });
+
+    eventsCenter.on('gameOver', () => {
+      this.scene.start('End', {
+        score: this.gm.score,
+      });
+    });
+  }
+
+  update(time: number, delta: number): void {
+    eventsCenter.emit('update', time, delta);
   }
 }

--- a/src/scenes/game/GameScene.ts
+++ b/src/scenes/game/GameScene.ts
@@ -18,23 +18,20 @@ export default class Game extends Scene {
     super('Game');
     this.gm = new GameController(
       new PhaseController(),
-      new CueGenerator(
-        [
-          CueFacet.CUE_FACETS[0],
-          CueFacet.CUE_FACETS[1],
-          CueFacet.CUE_FACETS[0],
-          CueFacet.CUE_FACETS[2],
-          CueFacet.CUE_FACETS[3],
-          CueFacet.CUE_FACETS[1],
-          CueFacet.CUE_FACETS[2],
-          CueFacet.CUE_FACETS[0],
-          CueFacet.CUE_FACETS[3],
-          CueFacet.CUE_FACETS[2],
-          CueFacet.CUE_FACETS[1],
-          CueFacet.CUE_FACETS[3],
-        ],
-        this
-      )
+      new CueGenerator([
+        CueFacet.CUE_FACETS[0],
+        CueFacet.CUE_FACETS[1],
+        CueFacet.CUE_FACETS[0],
+        CueFacet.CUE_FACETS[2],
+        CueFacet.CUE_FACETS[3],
+        CueFacet.CUE_FACETS[1],
+        CueFacet.CUE_FACETS[2],
+        CueFacet.CUE_FACETS[0],
+        CueFacet.CUE_FACETS[3],
+        CueFacet.CUE_FACETS[2],
+        CueFacet.CUE_FACETS[1],
+        CueFacet.CUE_FACETS[3],
+      ])
     );
   }
 

--- a/src/scenes/game/InputMediator.ts
+++ b/src/scenes/game/InputMediator.ts
@@ -1,4 +1,5 @@
 import { Events } from 'phaser';
+import eventsCenter from './EventsCenter';
 import CueFacet from './CueFacet';
 
 export enum InputEvents {
@@ -7,17 +8,14 @@ export enum InputEvents {
 }
 
 export default class InputMediator {
-  static mediateKeyboardStream(
-    source: Events.EventEmitter,
-    target: Events.EventEmitter
-  ): void {
+  static mediateKeyboardStream(source: Events.EventEmitter): void {
     source.on('keydown', (event: any) => {
       const code: number = event.keyCode;
       const cueResponse = CueFacet.getFacetForKey(code);
       if (cueResponse) {
-        target.emit('input', InputEvents.CUE_INPUT, cueResponse);
+        eventsCenter.emit('input', InputEvents.CUE_INPUT, cueResponse);
       } else {
-        target.emit('input', InputEvents.UNDEFINED, null);
+        eventsCenter.emit('input', InputEvents.UNDEFINED, null);
       }
     });
   }

--- a/src/scenes/game/PhaseController.spec.ts
+++ b/src/scenes/game/PhaseController.spec.ts
@@ -1,17 +1,10 @@
-import { Scene } from 'phaser';
 import PhaseController, { GamePhase } from './PhaseController';
+import eventsCenter from './EventsCenter';
 
-jest.mock('phaser', () => ({
-  __esModule: true,
-  Scene: jest.fn().mockImplementation(() => ({
-    events: {
-      emit: jest.fn(),
-      on: jest.fn(),
-    },
-  })),
+jest.mock('./EventsCenter', () => ({
+  emit: jest.fn(),
+  on: jest.fn(),
 }));
-
-const mockScene = new Scene({});
 
 describe('PhaseController', () => {
   beforeEach(() => {
@@ -20,11 +13,11 @@ describe('PhaseController', () => {
 
   describe('eventing', () => {
     it('endPhase emits a changePhase event, moves the current phase to the next one, and reset the timeInPhase', () => {
-      const pc = new PhaseController(mockScene);
+      const pc = new PhaseController();
       pc.currentPhase = GamePhase.PRESENTATION;
       pc.endPhase(false);
 
-      expect(mockScene.events.emit).toHaveBeenCalledWith(
+      expect(eventsCenter.emit).toHaveBeenCalledWith(
         'changePhase',
         GamePhase.PRESENTATION,
         GamePhase.RESPONSE_COLLECTION,
@@ -36,7 +29,7 @@ describe('PhaseController', () => {
     });
 
     it('responds to scene updates and progresses the phase after the phase duration has passed', () => {
-      const pc = new PhaseController(mockScene);
+      const pc = new PhaseController();
       jest.spyOn(pc, 'endPhase');
       pc.currentPhase = GamePhase.DISPLAY_RESULTS;
 
@@ -45,6 +38,21 @@ describe('PhaseController', () => {
 
       pc.handleUpdate(300);
       expect(pc.endPhase).toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('sets the phase back to START, clears timeInPhase, and sets gameOver to false', () => {
+      const pc = new PhaseController();
+      pc.currentPhase = GamePhase.RESPONSE_COLLECTION;
+      pc.timeInPhase = 230;
+      pc.gameOver = true;
+
+      pc.reset();
+
+      expect(pc.currentPhase).toBe(GamePhase.START);
+      expect(pc.timeInPhase).toBe(0);
+      expect(pc.gameOver).toBeFalsy();
     });
   });
 });

--- a/src/scenes/game/PhaseController.ts
+++ b/src/scenes/game/PhaseController.ts
@@ -48,9 +48,7 @@ export default class PhaseController {
     });
 
     eventsCenter.on('restart', () => {
-      this._currentPhase = GamePhase.START;
-      this._timeInPhase = 0;
-      this._gameOver = false;
+      this.reset();
     });
 
     eventsCenter.on('gameOver', () => {
@@ -82,6 +80,14 @@ export default class PhaseController {
     this._timeInPhase = timeInPhase;
   }
 
+  set gameOver(gameOver: boolean) {
+    this._gameOver = gameOver;
+  }
+
+  get gameOver(): boolean {
+    return this._gameOver;
+  }
+
   handleUpdate(delta: number): void {
     this._timeInPhase += delta;
     if (this._timeInPhase >= this.phaseDuration(this._currentPhase)) {
@@ -100,5 +106,11 @@ export default class PhaseController {
     );
     this._currentPhase = newPhase;
     this._timeInPhase = 0;
+  }
+
+  reset() {
+    this._currentPhase = GamePhase.START;
+    this._timeInPhase = 0;
+    this._gameOver = false;
   }
 }

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,3 +1,4 @@
 import Game from './game/GameScene';
+import End from './end/EndScene';
 
-export { Game };
+export { Game, End };


### PR DESCRIPTION
Closes #18 

Creates an end game scene displaying player's score, total hits, and longest streak. Provides a restart button to replay.

Moved eventing to an external eventEmitter to make creation/hanlding simpler and allow for later eventing between scenes if necessary.